### PR TITLE
Fixes the check whether the property 'options.copy' is a Boolean or not

### DIFF
--- a/src/dragula.js
+++ b/src/dragula.js
@@ -476,7 +476,9 @@ export class Dragula {
   }
 
   _isCopy(item, container) {
-    return typeof this.options.copy === 'boolean' ? this.options.copy : this.options.copy(item, container);
+    let isBoolean = typeof this.options.copy === 'boolean' ||
+      (typeof this.options.copy === 'object' && typeof this.options.copy.valueOf() === 'boolean');
+    return isBoolean ? this.options.copy : this.options.copy(item, container);
   }
 
 }

--- a/test/unit/dragulaanddrop.spec.js
+++ b/test/unit/dragulaanddrop.spec.js
@@ -63,6 +63,41 @@ describe('the Dragula and Drop Custom Element', function() {
     //assert
     expect(wasCalled).toBeTruthy();
   });
+  
+  it('should check copy-option correctly (boolean/true)', function() {
+    this.options.copy = true;
+    this.createDragula();
+    console.log(this.options.copy);
+    let isBoolean = this.dragulaAndDrop.dragula._isCopy(this.item, this.container);
+    this.dragulaAndDrop.dragula.options.isContainer(this.container);
+    
+    //assert
+    expect(isBoolean).toBeTruthy();
+  });
+  
+  it('should check copy-option correctly (boolean/false)', function() {
+    
+    this.options.copy = false; 
+    this.createDragula();
+    let isBoolean = this.dragulaAndDrop.dragula._isCopy(this.item, this.container);
+    this.dragulaAndDrop.dragula.options.isContainer(this.container);
+    
+    //assert
+    expect(isBoolean).toBeTruthy();
+  });
+  
+  it('should check copy-option correctly (function)', function() {
+    
+    this.options.copy = function (item, container) {
+      // can be empty
+    }; 
+    this.createDragula();
+    let isBoolean = this.dragulaAndDrop.dragula._isCopy(this.item, this.container);
+    this.dragulaAndDrop.dragula.options.isContainer(this.container);
+    
+    //assert
+    expect(isBoolean).toBeFalsy();
+  });
 
   it('should be able to determine container-ness from the classes if isContainer is not bound', function() {
     //arrange


### PR DESCRIPTION
Hi Michael,

the is a bug in the _isCopy method in the Dragula class where the check is done whether the option 'copy' is boolean or not. Currently you check via `typeof this.options.copy === 'boolean'` which results in 'object' (typeof new Boolean(true) results in 'object', see https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Operators/typeof). The PR fixes that. 

I have also added unit tests to check the new functionality.

Cheers,
Chris