### PR TITLE
Fixes "ReferenceError: _item is not defined" while dropping an element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 jspm_packages
 bower_components
 .idea
+.vscode
 .DS_STORE
 build/reports
 *.sublime-project

--- a/src/dragula.js
+++ b/src/dragula.js
@@ -251,7 +251,7 @@ export class Dragula {
   drop(item, target) {
     let parent = Util.getParent(item);
     if (this._copy && this.options.copySortSource && target === this._source) {
-      parent.removeChild(_item);
+      parent.removeChild(item);
     }
     if (this._isInitialPlacement(target)) {
       this._emitter.emit('cancel', item, this._source, this._source);

--- a/test/unit/dragulaanddrop.spec.js
+++ b/test/unit/dragulaanddrop.spec.js
@@ -67,7 +67,6 @@ describe('the Dragula and Drop Custom Element', function() {
   it('should check copy-option correctly (boolean/true)', function() {
     this.options.copy = true;
     this.createDragula();
-    console.log(this.options.copy);
     let isBoolean = this.dragulaAndDrop.dragula._isCopy(this.item, this.container);
     this.dragulaAndDrop.dragula.options.isContainer(this.container);
     


### PR DESCRIPTION
Hi Michael,

here is another small fix...when you drag an element and drop it on a target (where e.g. source and target are the same `UL`), then a ReferenceException may occur, because you use `_item `instead of `this._item` or `item` (from the method parameters).
Unfortunately, I have no unit test for this at the moment...but I think it is a very small change, should be ok though.

Cheers,
Chris