### PR TITLE
Update 'main' file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "author": "Michael Malone",
-  "main": "dist/index.js",
+  "main": "dist/commonjs/index.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/michaelmalonenz/aurelia-dragula.git"


### PR DESCRIPTION
Hello,

I noticed in using this with webpack, it points to `dist/index.js`, which does not exist.  It looks like [conventionally](https://github.com/aurelia/binding/blob/master/package.json#L16), this points to `dist/commonjs/index.js`.

Thanks!
