### PR TITLE
Check for controller on 'au' object

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -100,7 +100,7 @@ class _Util {
   }
 
   getViewModel(element) {
-    if (element && element.au) {
+    if (element && element.au && element.au.controller) {
       if (element.au.controller.viewModel.currentViewModel)
         return element.au.controller.viewModel.currentViewModel;
       else


### PR DESCRIPTION
Hello,

I encountered an issue when attempting to get the view model when beginning a drag.

I took a screenshot here:
<img width="585" alt="screen shot 2016-06-03 at 12 01 17 pm" src="https://cloud.githubusercontent.com/assets/1245874/15786603/2405c9c8-2983-11e6-85e6-b881cfcbbeb0.png">

It appears that I have a `show` attribute on this particular element, which creates the `au` object, but does not create the `controller` property.  I got around this by adding an additional check in the `if` statement.

I couldn't find any tests directly relating to this, but I'm happy to write some if you point me in the correct direction. 

Thanks!
