### PR TITLE
feat: typescript definition

### DIFF
--- a/aurelia-dragula.d.ts
+++ b/aurelia-dragula.d.ts
@@ -1,0 +1,47 @@
+declare namespace dragula {
+    
+    export interface DragulaOptions {
+        isContainer?: (el?: Element) => boolean;       
+        moves?: (el?: Element, source?: Element, handle?: Element, sibling?: Element) => boolean;
+        accepts?: (el?: Element, target?: Element, source?: Element, sibling?: Element) => boolean;
+        invalid?: (el?: Element, handle?: Element) => boolean;
+
+        direction?: string;
+        copy?: boolean;
+        copySortSource?: boolean;
+        revertOnSpill?: boolean;
+        removeOnSpill?: boolean;
+        mirrorContainer?: Element;
+        ignoreInputTextSelection?: boolean;
+
+        // Setting this option is effectively the same as passing the containers in the first argument to dragula(containers, options).
+        containers?: Array<Element>;
+    }
+
+    export interface Drake {
+        containers: Array<Element>;
+        dragging: boolean;
+        
+        start(item: Element): void;
+        end(): void;
+        cancel(revert?: boolean): void;
+        remove(): void;
+        on(events: string, callback: Function): void;
+        off(events: string, callback: Function): void;
+        once(events: string, callback: Function): void;
+        canMove(item: Element): boolean;
+        destroy(): void;
+    }
+
+    export interface Dragula {
+        new (containers: Element|Array<Element>, options?: DragulaOptions): Drake;
+        new (options?: DragulaOptions): Drake;
+        new (): Drake;
+    }
+}
+
+declare let Dragula: dragula.Dragula;
+
+declare module "aurelia-dragula" {
+    export default Dragula;
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "author": "Michael Malone",
   "main": "dist/commonjs/index.js",
+  "typings": "./aurelia-dragula.d.ts",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/michaelmalonenz/aurelia-dragula.git"

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,4 @@
+{
+  "name": "aurelia-dragula",
+  "main": "./aurelia-dragula.d.ts"
+}


### PR DESCRIPTION
Handwritten typescript definition, based upon version 3.7.1 of dragula. Left the emit and emitterSnapshot out of there, because they don't look like they should be used externally.

Placed the file in the root of your project, because if it is placed in dist it will be removed on clean and never generated again. You can move it anywhere you like, be sure to update the paths in typings.json and package.json.

Solves typescript definition not found on https://github.com/michaelmalonenz/aurelia-dragula/issues/19

Once the package is on npm, users can install the typings with:

```
typings i npm:aurelia-dragula --save
```

installing from github can be done also, but must be done as global, because it isn't version specific.
```
typings i github:michaelmalonenz/aurelia-dragula --global --save
```

