### PR TITLE
Fix webpack compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,13 @@
     "doc": "doc",
     "test": "test"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "aurelia": {
+    "build": {
+      "resources": [
+        "aurelia-dragula/dragula.css",
+        "aurelia-dragula/dragula-and-drop"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Fixed error "Cannot find module './aurelia-dragula/dragula-and-drop'" when using with webpack.