### PR TITLE
Update aurelia-dragula.d.ts

### DIFF
--- a/aurelia-dragula.d.ts
+++ b/aurelia-dragula.d.ts
@@ -42,6 +42,4 @@ declare namespace dragula {
   function moveBefore(array: Array<any>, itemMatcherFn: (item: Element) => boolean, siblingMatcherFn: (item: Element) => boolean)
 }
 
-declare module "aurelia-dragula" {
-    export default Dragula;
-}
+export = dragula;


### PR DESCRIPTION
This makes it so someone can import the namespace or individual classes/interfaces

import {Dragula, Options, moveBefore} from 'aurelia-dragula' or import * as dragula from 'aurelia-dragula'
which then can be used as dragula.moveBefore/dragula.Dragula/dragula.Options