### PR TITLE
to support new aurelia-webpack-plugin

### DIFF
--- a/src/dragula-and-drop.html
+++ b/src/dragula-and-drop.html
@@ -1,0 +1,3 @@
+<template>
+  <require from="./dragula.css"></require>
+</template>

--- a/src/dragula-and-drop.js
+++ b/src/dragula-and-drop.js
@@ -1,10 +1,9 @@
-import {customElement, bindable, noView} from 'aurelia-templating';
+import {customElement, bindable} from 'aurelia-templating';
 import {bindingMode} from 'aurelia-binding';
 import {inject} from 'aurelia-dependency-injection';
 
 import {Options, GLOBAL_OPTIONS} from './options';
 import {Dragula} from './dragula';
-import './dragula.css';
 
 @bindable({ name: 'moves', defaultBindingMode: bindingMode.oneTime })
 @bindable({ name: 'accepts', defaultBindingMode: bindingMode.oneTime })
@@ -28,7 +27,6 @@ import './dragula.css';
 @bindable({ name: 'outFn', attribute: 'out-fn', defaultBindingMode: bindingMode.oneTime })
 @bindable({ name: 'shadowFn', attribute: 'shadow-fn', defaultBindingMode: bindingMode.oneTime })
 @customElement('dragula-and-drop')
-@noView() // @inlineView('<template><require from="./dragula.css"></require></template>')
 @inject(GLOBAL_OPTIONS)
 export class DragulaAndDrop {
 

--- a/src/dragula-and-drop.js
+++ b/src/dragula-and-drop.js
@@ -1,4 +1,4 @@
-import {customElement, bindable} from 'aurelia-templating';
+import {customElement, bindable, useView} from 'aurelia-templating';
 import {bindingMode} from 'aurelia-binding';
 import {inject} from 'aurelia-dependency-injection';
 
@@ -26,6 +26,7 @@ import {Dragula} from './dragula';
 @bindable({ name: 'overFn', attribute: 'over-fn', defaultBindingMode: bindingMode.oneTime })
 @bindable({ name: 'outFn', attribute: 'out-fn', defaultBindingMode: bindingMode.oneTime })
 @bindable({ name: 'shadowFn', attribute: 'shadow-fn', defaultBindingMode: bindingMode.oneTime })
+@useView('./dragula-and-drop.html')
 @customElement('dragula-and-drop')
 @inject(GLOBAL_OPTIONS)
 export class DragulaAndDrop {

--- a/src/dragula-and-drop.js
+++ b/src/dragula-and-drop.js
@@ -1,9 +1,10 @@
-import {customElement, bindable, inlineView} from 'aurelia-templating';
+import {customElement, bindable, noView} from 'aurelia-templating';
 import {bindingMode} from 'aurelia-binding';
 import {inject} from 'aurelia-dependency-injection';
 
 import {Options, GLOBAL_OPTIONS} from './options';
 import {Dragula} from './dragula';
+import './dragula.css';
 
 @bindable({ name: 'moves', defaultBindingMode: bindingMode.oneTime })
 @bindable({ name: 'accepts', defaultBindingMode: bindingMode.oneTime })
@@ -27,7 +28,7 @@ import {Dragula} from './dragula';
 @bindable({ name: 'outFn', attribute: 'out-fn', defaultBindingMode: bindingMode.oneTime })
 @bindable({ name: 'shadowFn', attribute: 'shadow-fn', defaultBindingMode: bindingMode.oneTime })
 @customElement('dragula-and-drop')
-@inlineView('<template><require from="./dragula.css"></require></template>')
+@noView() // @inlineView('<template><require from="./dragula.css"></require></template>')
 @inject(GLOBAL_OPTIONS)
 export class DragulaAndDrop {
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import {Options, GLOBAL_OPTIONS, DIRECTION} from './options';
 import {Dragula} from './dragula';
 import {moveBefore} from './move-before';
+// import {PLATFORM} from 'aurelia-framework'; // PLATFORM is already available
 
 export {Dragula, Options, DIRECTION, moveBefore};
 
@@ -12,5 +13,5 @@ export function configure(config, callback) {
     callback(defaults);
   }
 
-  config.globalResources(['./dragula-and-drop']);
+  config.globalResources([PLATFORM.moduleName('./dragula-and-drop')]);
 }


### PR DESCRIPTION
Made the changes needed in `src/index.js` and `src/dragula-and-drop.js` to support v2 of `aurelia-webpack-plugin`. Note this is backward compatible with previous `aurelia-webpack-plugin` versions.
See discussion of the issue [here](https://github.com/michaelmalonenz/aurelia-dragula/issues/33).

Note that `gulp build` need to be performed before publishing to npm so that files in `dist/` are updated.